### PR TITLE
c++11 compatibility

### DIFF
--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,4 +1,6 @@
 #include <gtest/gtest.h>
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
 
 #define CR_HOST
 #include "../cr.h"


### PR DESCRIPTION
Replaced c++17 std::filesystem usage with platform api calls in order to support compiling with older compilers.