### PR TITLE
Few fixes

### DIFF
--- a/cr.h
+++ b/cr.h
@@ -929,7 +929,7 @@ static int cr_plugin_main(cr_plugin &ctx, cr_op operation) {
     } __except (cr_seh_filter(ctx, GetExceptionCode())) {
         return -1;
     }
-    return 0;
+    return -1;
 }
 
 #endif // _WIN32
@@ -1278,7 +1278,7 @@ static int cr_plugin_main(cr_plugin &ctx, cr_op operation) {
         }
     }
 
-    return 0;
+    return -1;
 }
 #endif // __unix__
 

--- a/cr.h
+++ b/cr.h
@@ -922,13 +922,17 @@ static int cr_seh_filter(cr_plugin &ctx, unsigned long seh) {
 
 static int cr_plugin_main(cr_plugin &ctx, cr_op operation) {
     auto p = (cr_internal *)ctx.p;
+#ifndef __MINGW32__
     __try {
+#endif
         if (p->main) {
             return p->main(&ctx, operation);
         }
+#ifndef __MINGW32__
     } __except (cr_seh_filter(ctx, GetExceptionCode())) {
         return -1;
     }
+#endif
     return -1;
 }
 


### PR DESCRIPTION
Fixed #7.

Also disabled use of seh exceptions when compiling with MingW as they are not supported with said compiler. Actually MingW somewhat supports them with custom `__try1`/`__except1` macros, but they do not map 1:1. Disabling seh exceptions will loose ability to rollback but hey, at least everything compiles and works as long as there are no crashes.