### PR TITLE
Fix build with mingw failing to find std::memcpy.

### DIFF
--- a/cr.h
+++ b/cr.h
@@ -445,6 +445,7 @@ struct cr_plugin {
 #include <algorithm>
 #include <cassert> // assert
 #include <chrono>  // duration for sleep
+#include <cstring> // memcpy
 #include <string>
 #include <thread> // this_thread::sleep_for
 


### PR DESCRIPTION
As title says. Without this include i had to change `std::memcpy` to `memcpy` for it to build with mingw.