### PR TITLE
overridable macros

### DIFF
--- a/cr.h
+++ b/cr.h
@@ -226,6 +226,19 @@ Usage
 
 `static bool CR_STATE bInitialized = false;`
 
+#### Overridable macros
+
+You can define these macros before including cr.h in host (CR_HOST) to customize cr.h
+ memory allocations and other behaviours:
+
+- `CR_MAIN_FUNC`: changes 'cr_main' symbol to user-defined function name. default: #define CR_MAIN_FUNC "cr_main"
+- `CR_ASSERT`: override assert. default: #define CA_ASSERT(e) assert(e)
+- `CR_REALLOC`: override libc's realloc. default: #define CR_REALLOC(ptr, size) ::realloc(ptr, size)
+- `CR_MALLOC`: override libc's malloc. default: #define CR_MALLOC(size) ::malloc(size)
+- `CR_FREE`: override libc's free. default: #define CR_FREE(ptr) ::free(ptr)
+- `CR_DEBUG`: outputs debug messages in CR_LOG and CR_TRACE 
+- `CR_LOG`: logs debug messages. default (CR_DEBUG only): #define CR_LOG(...) fprintf(stdout, __VA_ARGS__)
+- `CR_TRACE`: prints function calls. default (CR_DEBUG only): #define CR_TRACE(...) fprintf(stdout, "CR_TRACE: %s\n", __FUNCTION__)
 
 ### FAQ / Troubleshooting
 
@@ -364,14 +377,6 @@ platform should be supported."
 #define CR_IMPORT
 #endif // defined(__GNUC__)
 
-#if defined(CR_DEBUG)
-#define CR_TRACE    fprintf(stdout, "CR_TRACE: %s\n", __FUNCTION__);
-#define CR_LOG(...) fprintf(stdout, __VA_ARGS__);
-#else
-#define CR_TRACE
-#define CR_LOG(...)
-#endif
-
 // cr_mode defines how much we validate global state transfer between
 // instances. The default is CR_UNSAFE, you can choose another mode by
 // defining CR_HOST, ie.: #define CR_HOST CR_SAFEST
@@ -448,9 +453,52 @@ struct cr_plugin {
 
 #else // #ifndef CR_HOST
 
+// Overridable macros
+#ifndef CR_LOG
+#   ifdef CR_DEBUG
+#       include <stdio.h>
+#       define CR_LOG(...)     fprintf(stdout, __VA_ARGS__)
+#   else
+#       define CR_LOG(...)     
+#   endif
+#endif
+
+#ifndef CR_TRACE
+#   ifdef CR_DEBUG
+#       include <stdio.h>
+#       define CR_TRACE        fprintf(stdout, "CR_TRACE: %s\n", __FUNCTION__);
+#   else
+#       define CR_TRACE     
+#   endif
+#endif
+
+#ifndef CR_MAIN_FUNC
+#   define CR_MAIN_FUNC "cr_main"
+#endif
+
+#ifndef CR_ASSERT
+#   include <assert.h>
+#   define CR_ASSERT(e)             assert(e)
+#endif
+
+#ifndef CR_REALLOC
+#   include <stdlib.h>
+#   define CR_REALLOC(ptr, size)   ::realloc(ptr, size)
+#endif
+
+#ifndef CR_FREE
+#   include <stdlib.h>
+#   define CR_FREE(ptr)            ::free(ptr)
+#endif
+
+#ifndef CR_MALLOC
+#   include <stdlib.h>
+#   define CR_MALLOC(size)         ::malloc(size)
+#endif
+
 #if defined(_MSC_VER)
 // we should probably push and pop this
-#pragma warning(disable:4003) // not enough actual parameters for macro 'identifier'
+#   pragma warning(disable:4003) // not enough actual parameters for macro 'identifier'
 #endif
 
 #define CR_DO_EXPAND(x) x##1337
@@ -463,7 +511,6 @@ struct cr_plugin {
 #endif
 
 #include <algorithm>
-#include <cassert> // assert
 #include <chrono>  // duration for sleep
 #include <cstring> // memcpy
 #include <string>
@@ -708,7 +755,7 @@ static bool cr_pe_fileoffset_rva(PIMAGE_NT_HEADERS ntHeaders, DWORD rva,
 }
 
 static char *cr_pdb_find(LPBYTE imageBase, PIMAGE_DEBUG_DIRECTORY debugDir) {
-    assert(debugDir && imageBase);
+    CR_ASSERT(debugDir && imageBase);
     LPBYTE debugInfo = imageBase + debugDir->PointerToRawData;
     const auto debugInfoSize = debugDir->SizeOfData;
     if (debugInfo == 0 || debugInfoSize == 0) {
@@ -745,7 +792,7 @@ static char *cr_pdb_find(LPBYTE imageBase, PIMAGE_DEBUG_DIRECTORY debugDir) {
 static bool cr_pdb_replace(const std::string &filename,
                            const std::string &pdbname, char *pdbnamebuf,
                            int pdbnamelen) {
-    assert(pdbnamebuf);
+    CR_ASSERT(pdbnamebuf);
     HANDLE fp = nullptr;
     HANDLE filemap = nullptr;
     LPVOID mem = 0;
@@ -898,7 +945,7 @@ static void cr_pe_section_save(cr_plugin &ctx, cr_plugin_section_type::e type,
     data->base = base;
     data->ptr = (char *)vaddr;
     data->size = shdr.SizeOfRawData;
-    data->data = realloc(data->data, shdr.SizeOfRawData);
+    data->data = CR_REALLOC(data->data, shdr.SizeOfRawData);
     if (old_size < shdr.SizeOfRawData) {
         memset((char *)data->data + old_size, '\0',
                shdr.SizeOfRawData - old_size);
@@ -909,7 +956,7 @@ static bool cr_plugin_validate_sections(cr_plugin &ctx, so_handle handle,
                                         const std::string &imagefile,
                                         bool rollback) {
     (void)imagefile;
-    assert(handle);
+    CR_ASSERT(handle);
     auto p = (cr_internal *)ctx.p;
     if (p->mode == CR_DISABLE) {
         return true;
@@ -952,7 +999,7 @@ static bool cr_plugin_validate_sections(cr_plugin &ctx, so_handle handle,
 
 static void cr_so_unload(cr_plugin &ctx) {
     auto p = (cr_internal *)ctx.p;
-    assert(p->handle);
+    CR_ASSERT(p->handle);
     FreeLibrary((HMODULE)p->handle);
 }
 
@@ -965,8 +1012,8 @@ static so_handle cr_so_load(const std::string &filename) {
 }
 
 static cr_plugin_main_func cr_so_symbol(so_handle handle) {
-    assert(handle);
-    auto new_main = (cr_plugin_main_func)GetProcAddress(handle, "cr_main");
+    CR_ASSERT(handle);
+    auto new_main = (cr_plugin_main_func)GetProcAddress(handle, CR_MAIN_FUNC);
     if (!new_main) {
         fprintf(stderr, "Couldn't find plugin entry point: %d\n",
                 GetLastError());
@@ -1119,7 +1166,7 @@ void cr_elf_section_save(cr_plugin &ctx, cr_plugin_section_type::e type,
     data->base = base;
     data->ptr = (char *)vaddr;
     data->size = shdr.sh_size;
-    data->data = realloc(data->data, shdr.sh_size);
+    data->data = CR_REALLOC(data->data, shdr.sh_size);
     if (old_size < shdr.sh_size) {
         memset((char *)data->data + old_size, '\0', shdr.sh_size - old_size);
     }
@@ -1134,7 +1181,7 @@ void cr_elf_section_save(cr_plugin &ctx, cr_plugin_section_type::e type,
 template <class H>
 bool cr_elf_validate_sections(cr_plugin &ctx, bool rollback, H shdr, int shnum,
                               const char *sh_strtab_p) {
-    assert(sh_strtab_p);
+    CR_ASSERT(sh_strtab_p);
     auto p = (cr_internal *)ctx.p;
     bool result = true;
     for (int i = 0; i < shnum; ++i) {
@@ -1197,7 +1244,7 @@ struct cr_ld_data {
 // https://eli.thegreenplace.net/2011/08/25/load-time-relocation-of-shared-libraries/
 static int cr_dl_header_handler(struct dl_phdr_info *info, size_t size,
                                 void *data) {
-    assert(info && data);
+    CR_ASSERT(info && data);
     auto p = (cr_ld_data *)data;
     auto ctx = p->ctx;
     if (strcasecmp(info->dlpi_name, p->fullname)) {
@@ -1227,7 +1274,7 @@ static int cr_dl_header_handler(struct dl_phdr_info *info, size_t size,
 static bool cr_plugin_validate_sections(cr_plugin &ctx, so_handle handle,
                                         const std::string &imagefile,
                                         bool rollback) {
-    assert(handle);
+    CR_ASSERT(handle);
     cr_ld_data data;
     data.ctx = &ctx;
     auto pimpl = (cr_internal *)ctx.p;
@@ -1309,7 +1356,7 @@ void cr_macho_section_save(cr_plugin &ctx, cr_plugin_section_type::e type,
     data->base = 0;
     data->ptr = (char *)addr;
     data->size = size;
-    data->data = realloc(data->data, size);
+    data->data = CR_REALLOC(data->data, size);
     if (old_size < size) {
         memset((char *)data->data + old_size, '\0', size - old_size);
     }
@@ -1335,7 +1382,7 @@ static bool cr_plugin_validate_sections(cr_plugin &ctx, so_handle handle,
     // resolve absolute path of the image, because _dyld_get_image_name returns abs path
     char imageAbsPath[PATH_MAX+1];
     if (!::realpath(imagefile.c_str(), imageAbsPath)) {
-        assert(0 && "resolving absolute path for plugin failed");
+        CR_ASSERT(0 && "resolving absolute path for plugin failed");
         return false;
     }
 
@@ -1390,9 +1437,9 @@ static bool cr_plugin_validate_sections(cr_plugin &ctx, so_handle handle,
 #endif
 
 static void cr_so_unload(cr_plugin &ctx) {
-    assert(ctx.p);
+    CR_ASSERT(ctx.p);
     auto p = (cr_internal *)ctx.p;
-    assert(p->handle);
+    CR_ASSERT(p->handle);
 
     const int r = dlclose(p->handle);
     if (r) {
@@ -1413,9 +1460,9 @@ static so_handle cr_so_load(const std::string &new_file) {
 }
 
 static cr_plugin_main_func cr_so_symbol(so_handle handle) {
-    assert(handle);
+    CR_ASSERT(handle);
     dlerror();
-    auto new_main = (cr_plugin_main_func)dlsym(handle, "cr_main");
+    auto new_main = (cr_plugin_main_func)dlsym(handle, CR_MAIN_FUNC);
     if (!new_main) {
         fprintf(stderr, "Couldn't find plugin entry point: %s\n", dlerror());
     }
@@ -1427,7 +1474,7 @@ sigjmp_buf env;
 static void cr_signal_handler(int sig, siginfo_t *si, void *uap) {
     CR_TRACE
     (void)uap;
-    assert(si);
+    CR_ASSERT(si);
     siglongjmp(env, sig);
 }
 
@@ -1479,7 +1526,7 @@ static int cr_plugin_main(cr_plugin &ctx, cr_op operation) {
         return -1;
     } else {
         auto p = (cr_internal *)ctx.p;
-        assert(p);
+        CR_ASSERT(p);
         if (p->main) {
             return p->main(&ctx, operation);
         }
@@ -1498,7 +1545,7 @@ static bool cr_plugin_load_internal(cr_plugin &ctx, bool rollback) {
         const auto new_file = cr_version_path(file, ctx.version);
 
         const bool close = false;
-        CR_LOG("unload with rollback: %d\n", rollback);
+        CR_LOG("unload '%s' with rollback: %d\n", file.c_str(), rollback);
         cr_plugin_unload(ctx, rollback, close);
         if (!rollback) {
             cr_copy(file, new_file);
@@ -1547,7 +1594,7 @@ static bool cr_plugin_load_internal(cr_plugin &ctx, bool rollback) {
             p2->timestamp = cr_last_write_time(file);
         }
         ctx.version++;
-        CR_LOG("1 LOADED VERSION: %d\n", ctx.version);
+        CR_LOG("loaded: %s (version: %d)\n", new_file.c_str(), ctx.version);
     } else {
         fprintf(stderr, "Error loading plugin.\n");
         return false;
@@ -1588,7 +1635,7 @@ static void cr_plugin_sections_backup(cr_plugin &ctx) {
         auto cur = &p->data[i][cr_plugin_section_version::current];
         if (cur->ptr) {
             auto bkp = &p->data[i][cr_plugin_section_version::backup];
-            bkp->data = realloc(bkp->data, cur->size);
+            bkp->data = CR_REALLOC(bkp->data, cur->size);
             bkp->ptr = cur->ptr;
             bkp->size = cur->size;
             bkp->base = cur->base;
@@ -1630,7 +1677,7 @@ static void cr_plugin_sections_store(cr_plugin &ctx) {
 // internal copy created during the unload step.
 static void cr_plugin_sections_reload(cr_plugin &ctx,
                                       cr_plugin_section_version::e version) {
-    assert(version < cr_plugin_section_version::count);
+    CR_ASSERT(version < cr_plugin_section_version::count);
     auto p = (cr_internal *)ctx.p;
     if (p->mode == CR_DISABLE) {
         return;
@@ -1660,7 +1707,7 @@ static void cr_so_sections_free(cr_plugin &ctx) {
     for (int i = 0; i < cr_plugin_section_type::count; ++i) {
         for (int v = 0; v < cr_plugin_section_version::count; ++v) {
             if (p->data[i][v].data) {
-                free(p->data[i][v].data);
+                CR_FREE(p->data[i][v].data);
             }
             p->data[i][v].data = nullptr;
         }
@@ -1764,8 +1811,8 @@ extern "C" int cr_plugin_update(cr_plugin &ctx, bool reloadCheck = true) {
 // Loads a plugin from the specified full path (or current directory if NULL).
 extern "C" bool cr_plugin_load(cr_plugin &ctx, const char *fullpath) {
     CR_TRACE
-    assert(fullpath);
-    auto p = new cr_internal;
+    CR_ASSERT(fullpath);
+    auto p = new(CR_MALLOC(sizeof(cr_internal))) cr_internal;
     p->mode = CR_OP_MODE;
     p->fullname = fullpath;
     ctx.p = p;
@@ -1783,7 +1830,8 @@ extern "C" void cr_plugin_close(cr_plugin &ctx) {
     cr_plugin_unload(ctx, rollback, close);
     cr_so_sections_free(ctx);
     auto p = (cr_internal *)ctx.p;
-    delete p;
+    p->~cr_internal();
+    CR_FREE(p);
     ctx.p = nullptr;
     ctx.version = 0;
 }


### PR DESCRIPTION
this PR is for the 1 and 2 I suggested [here](https://github.com/fungos/cr/issues/16#issuecomment-445485181)

I also relocated the macros to the CR_HOST section. in order to have a less cluttered header entry and also move the included headers to the host implementation only.

I also changed the CR_LOG/CR_TRACE override pattern, to let the user define his own debug logger function.

Every macro has a default behavior like before, Hopefully it doesn't break anything