### PR TITLE
added ascii only filepath option for windows

### DIFF
--- a/cr.h
+++ b/cr.h
@@ -239,6 +239,7 @@ You can define these macros before including cr.h in host (CR_HOST) to customize
 - `CR_DEBUG`: outputs debug messages in CR_LOG and CR_TRACE 
 - `CR_LOG`: logs debug messages. default (CR_DEBUG only): #define CR_LOG(...) fprintf(stdout, __VA_ARGS__)
 - `CR_TRACE`: prints function calls. default (CR_DEBUG only): #define CR_TRACE(...) fprintf(stdout, "CR_TRACE: %s\n", __FUNCTION__)
+- `CR_WINDOWS_UTF8_PATHS`: on windows platform, set this to zero to restrict the api to ascii file paths only (for better performance). (default: 1)
 
 ### FAQ / Troubleshooting
 
@@ -496,6 +497,10 @@ struct cr_plugin {
 #   define CR_MALLOC(size)         ::malloc(size)
 #endif
 
+#ifndef CR_WINDOWS_UTF8_PATHS
+#   define CR_WINDOWS_UTF8_PATHS    1
+#endif
+
 #if defined(_MSC_VER)
 // we should probably push and pop this
 #   pragma warning(disable:4003) // not enough actual parameters for macro 'identifier'
@@ -611,6 +616,9 @@ static int cr_plugin_main(cr_plugin &ctx, cr_op operation);
 #if defined(CR_WINDOWS)
 
 // clang-format off
+#ifndef WIN32_LEAN_AND_MEAN
+#   define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #include <dbghelp.h>
 // clang-format on
@@ -619,6 +627,7 @@ static int cr_plugin_main(cr_plugin &ctx, cr_op operation);
 
 using so_handle = HMODULE;
 
+#if CR_WINDOWS_UTF8_PATHS
 static std::wstring cr_utf8_to_wstring(const std::string &str) {
     int wlen = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, 0, 0);
     wchar_t wpath_small[MAX_PATH];
@@ -669,6 +678,32 @@ static void cr_del(const std::string& path) {
     std::wstring wpath = cr_utf8_to_wstring(path);
     DeleteFileW(wpath.c_str());
 }
+#else
+static time_t cr_last_write_time(const std::string &path) {
+    WIN32_FILE_ATTRIBUTE_DATA fad;
+    if (!GetFileAttributesExA(path.c_str(), GetFileExInfoStandard, &fad)) {
+        return -1;
+    }
+
+    LARGE_INTEGER time;
+    time.HighPart = fad.ftLastWriteTime.dwHighDateTime;
+    time.LowPart = fad.ftLastWriteTime.dwLowDateTime;
+
+    return static_cast<time_t>(time.QuadPart / 10000000 - 11644473600LL);
+}
+
+static bool cr_exists(const std::string &path) {
+    return GetFileAttributesA(path.c_str()) != INVALID_FILE_ATTRIBUTES;
+}
+
+static void cr_copy(const std::string &from, const std::string &to) {
+    CopyFileA(from.c_str(), to.c_str(), false);
+}
+
+static void cr_del(const std::string& path) {
+    DeleteFileA(path.c_str());
+}
+#endif // CR_WINDOWS_UTF8_PATHS
 
 // If using Microsoft Visual C/C++ compiler we need to do some workaround the
 // fact that the compiled binary has a fullpath to the PDB hardcoded inside

--- a/cr.h
+++ b/cr.h
@@ -251,7 +251,6 @@ You can define these macros before including cr.h in host (CR_HOST) to customize
 - `CR_ERROR`: logs debug messages to stderr. default (CR_DEBUG only): #define CR_ERROR(...) fprintf(stderr, __VA_ARGS__)
 - `CR_LOG`: logs debug messages. default (CR_DEBUG only): #define CR_LOG(...) fprintf(stdout, __VA_ARGS__)
 - `CR_TRACE`: prints function calls. default (CR_DEBUG only): #define CR_TRACE(...) fprintf(stdout, "CR_TRACE: %s\n", __FUNCTION__)
-- `CR_WINDOWS_UTF8_PATHS`: on windows platform, set this to zero to restrict the api to ascii file paths only (for better performance). (default: 1)
 
 ### FAQ / Troubleshooting
 
@@ -518,10 +517,6 @@ struct cr_plugin {
 #   define CR_MALLOC(size)         ::malloc(size)
 #endif
 
-#ifndef CR_WINDOWS_UTF8_PATHS
-#   define CR_WINDOWS_UTF8_PATHS    1
-#endif
-
 #if defined(_MSC_VER)
 // we should probably push and pop this
 #   pragma warning(disable:4003) // not enough actual parameters for macro 'identifier'
@@ -658,7 +653,9 @@ static void cr_set_temporary_path(cr_plugin &ctx, const std::string &path) {
 
 using so_handle = HMODULE;
 
-#if CR_WINDOWS_UTF8_PATHS
+#ifdef UNICODE
+#   define CR_WINDOWS_ConvertPath(_newpath, _path)     std::wstring _newpath(cr_utf8_to_wstring(_path))
+
 static std::wstring cr_utf8_to_wstring(const std::string &str) {
     int wlen = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, 0, 0);
     wchar_t wpath_small[MAX_PATH];
@@ -675,11 +672,14 @@ static std::wstring cr_utf8_to_wstring(const std::string &str) {
 
     return wpath;
 }
+#else
+#   define CR_WINDOWS_ConvertPath(_newpath, _path)     const std::string &_newpath = _path
+#endif  // UNICODE
 
 static time_t cr_last_write_time(const std::string &path) {
-    std::wstring wpath = cr_utf8_to_wstring(path);
+    CR_WINDOWS_ConvertPath(_path, path);
     WIN32_FILE_ATTRIBUTE_DATA fad;
-    if (!GetFileAttributesExW(wpath.c_str(), GetFileExInfoStandard, &fad)) {
+    if (!GetFileAttributesEx(_path.c_str(), GetFileExInfoStandard, &fad)) {
         return -1;
     }
 
@@ -695,46 +695,20 @@ static time_t cr_last_write_time(const std::string &path) {
 }
 
 static bool cr_exists(const std::string &path) {
-    std::wstring wpath = cr_utf8_to_wstring(path);
-    return GetFileAttributesW(wpath.c_str()) != INVALID_FILE_ATTRIBUTES;
+    CR_WINDOWS_ConvertPath(_path, path);
+    return GetFileAttributes(_path.c_str()) != INVALID_FILE_ATTRIBUTES;
 }
 
 static bool cr_copy(const std::string &from, const std::string &to) {
-    std::wstring wfrom = cr_utf8_to_wstring(from);
-    std::wstring wto = cr_utf8_to_wstring(to);
-    return CopyFileW(wfrom.c_str(), wto.c_str(), false) != false;
+    CR_WINDOWS_ConvertPath(_from, from);
+    CR_WINDOWS_ConvertPath(_to, to);
+    return CopyFile(_from.c_str(), _to.c_str(), FALSE) ? true : false;
 }
 
 static void cr_del(const std::string& path) {   
-    std::wstring wpath = cr_utf8_to_wstring(path);
-    DeleteFileW(wpath.c_str());
+    CR_WINDOWS_ConvertPath(_path, path);
+    DeleteFile(_path.c_str());
 }
-#else
-static time_t cr_last_write_time(const std::string &path) {
-    WIN32_FILE_ATTRIBUTE_DATA fad;
-    if (!GetFileAttributesExA(path.c_str(), GetFileExInfoStandard, &fad)) {
-        return -1;
-    }
-
-    LARGE_INTEGER time;
-    time.HighPart = fad.ftLastWriteTime.dwHighDateTime;
-    time.LowPart = fad.ftLastWriteTime.dwLowDateTime;
-
-    return static_cast<time_t>(time.QuadPart / 10000000 - 11644473600LL);
-}
-
-static bool cr_exists(const std::string &path) {
-    return GetFileAttributesA(path.c_str()) != INVALID_FILE_ATTRIBUTES;
-}
-
-static void cr_copy(const std::string &from, const std::string &to) {
-    CopyFileA(from.c_str(), to.c_str(), false);
-}
-
-static void cr_del(const std::string& path) {
-    DeleteFileA(path.c_str());
-}
-#endif // CR_WINDOWS_UTF8_PATHS
 
 // If using Microsoft Visual C/C++ compiler we need to do some workaround the
 // fact that the compiled binary has a fullpath to the PDB hardcoded inside
@@ -864,12 +838,14 @@ static bool cr_pdb_replace(const std::string &filename,
                            const std::string &pdbname, char *pdbnamebuf,
                            int pdbnamelen) {
     CR_ASSERT(pdbnamebuf);
+    CR_WINDOWS_ConvertPath(_filename, filename);
+
     HANDLE fp = nullptr;
     HANDLE filemap = nullptr;
     LPVOID mem = 0;
     bool result = false;
     do {
-        fp = CreateFile(filename.c_str(), GENERIC_READ | GENERIC_WRITE,
+        fp = CreateFile(_filename.c_str(), GENERIC_READ | GENERIC_WRITE,
                         FILE_SHARE_READ, nullptr, OPEN_EXISTING,
                         FILE_ATTRIBUTE_NORMAL, nullptr);
         if ((fp == INVALID_HANDLE_VALUE) || (fp == nullptr)) {
@@ -1001,7 +977,7 @@ bool static cr_pdb_process(const std::string &filename,
     char orig_pdb[MAX_PATH];
     memset(orig_pdb, 0, sizeof(orig_pdb));
     bool result = cr_pdb_replace(filename, pdbname, orig_pdb, sizeof(orig_pdb));
-    result &= static_cast<bool>(CopyFile(orig_pdb, pdbname.c_str(), 0));
+    result &= cr_copy(orig_pdb, pdbname);
     return result;
 }
 #endif // _MSC_VER
@@ -1075,7 +1051,8 @@ static void cr_so_unload(cr_plugin &ctx) {
 }
 
 static so_handle cr_so_load(const std::string &filename) {
-    auto new_dll = LoadLibrary(filename.c_str());
+    CR_WINDOWS_ConvertPath(_filename, filename);
+    auto new_dll = LoadLibrary(_filename.c_str());
     if (!new_dll) {
         CR_ERROR("Couldn't load plugin: %d\n", GetLastError());
     }


### PR DESCRIPTION
Added an option *CR_WINDOWS_UTF8_PATHS* to disable utf8 path implementation for windows and use ascii paths only. mainly for performance reasons.
also added WIN32_LEAN_AND_MEAN for faster compile times

I also noticed that *cr_copy* posix implementation is pretty slow and there's a much robust method for copying files in unix, I'll submit another PR for that.
