### PR TITLE
Issue with handling unload crashes.

### DIFF
--- a/cr.h
+++ b/cr.h
@@ -1621,7 +1621,7 @@ static bool cr_plugin_load_internal(cr_plugin &ctx, bool rollback) {
         CR_LOG("unload '%s' with rollback: %d\n", old_file.c_str(), rollback);
         cr_plugin_unload(ctx, rollback, false);
 
-        auto new_version = ctx.version + 1;
+        auto new_version = ctx.version + (rollback ? 0 : 1);
         const auto new_file = cr_version_path(file, new_version, p->temppath);
         if (!rollback) {
             cr_copy(file, new_file);
@@ -1822,7 +1822,6 @@ static void cr_plugin_unload(cr_plugin &ctx, bool rollback, bool close) {
 // in turn may also cause more rollbacks.
 static bool cr_plugin_rollback(cr_plugin &ctx) {
     CR_TRACE
-    ctx.version = ctx.version > 0 ? ctx.version - 1 : 0;
     auto loaded = cr_plugin_load_internal(ctx, true);
     if (loaded) {
         loaded = cr_plugin_main(ctx, CR_LOAD) >= 0;

--- a/cr.h
+++ b/cr.h
@@ -637,7 +637,7 @@ static void cr_plugin_sections_reload(cr_plugin &ctx,
 static void cr_plugin_sections_store(cr_plugin &ctx);
 static void cr_plugin_sections_backup(cr_plugin &ctx);
 static void cr_plugin_reload(cr_plugin &ctx);
-static void cr_plugin_unload(cr_plugin &ctx, bool rollback, bool close);
+static int cr_plugin_unload(cr_plugin &ctx, bool rollback, bool close);
 static bool cr_plugin_changed(cr_plugin &ctx);
 static bool cr_plugin_rollback(cr_plugin &ctx);
 static int cr_plugin_main(cr_plugin &ctx, cr_op operation);
@@ -1619,7 +1619,10 @@ static bool cr_plugin_load_internal(cr_plugin &ctx, bool rollback) {
     if (cr_exists(file) || rollback) {
         const auto old_file = cr_version_path(file, ctx.version, p->temppath);
         CR_LOG("unload '%s' with rollback: %d\n", old_file.c_str(), rollback);
-        cr_plugin_unload(ctx, rollback, false);
+        int r = cr_plugin_unload(ctx, rollback, false);
+        if (r < 0) {
+            return false;
+        }
 
         auto new_version = ctx.version + (rollback ? 0 : 1);
         const auto new_file = cr_version_path(file, new_version, p->temppath);
@@ -1802,18 +1805,25 @@ static bool cr_plugin_changed(cr_plugin &ctx) {
 // unload is due a rollback, no `cr_op::CR_UNLOAD` is called neither any state
 // is saved, giving opportunity to the previous version to continue with valid
 // previous state.
-static void cr_plugin_unload(cr_plugin &ctx, bool rollback, bool close) {
+static int cr_plugin_unload(cr_plugin &ctx, bool rollback, bool close) {
     CR_TRACE
     auto p = (cr_internal *)ctx.p;
+    int r = 0;
     if (p->handle) {
         if (!rollback) {
-            cr_plugin_main(ctx, close ? CR_CLOSE : CR_UNLOAD);
-            cr_plugin_sections_store(ctx);
+            r = cr_plugin_main(ctx, close ? CR_CLOSE : CR_UNLOAD);
+            // Don't store state if unload crashed.  Rollback will use backup.
+            if (r < 0) {
+                CR_LOG("4 FAILURE: %d\n", r);
+            } else {
+                cr_plugin_sections_store(ctx);
+            }
         }
         cr_so_unload(ctx);
         p->handle = nullptr;
         p->main = nullptr;
     }
+    return r;
 }
 
 // internal

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -148,15 +148,15 @@ TEST(crTest, basic_flow) {
     touch(bin);
 
     // force crash on unload
-    // but now the bug moved and crashed again, we're back to version 2
+    // but now the bug moved and crashed again, we're back to version 1
     data.test = test_id::crash_unload;
     EXPECT_EQ(-2, cr_plugin_update(ctx));
-    EXPECT_EQ((unsigned int)2, ctx.version);
+    EXPECT_EQ((unsigned int)1, ctx.version);
     EXPECT_EQ(CR_SEGFAULT, ctx.failure);
 
-    // unload crashed, should still restore version 2
+    // unload crashed, next update should do a rollback
     data.test = test_id::return_version;
-    EXPECT_EQ(2, cr_plugin_update(ctx));
+    EXPECT_EQ(1, cr_plugin_update(ctx));
 
     // modify states
     data.test = test_id::static_local_state_int;


### PR DESCRIPTION

Previous logic:
1. Plugin is at version 2.
2. New version 3 is detected.
3. Unload of version 2 crashes.  (State is saved from version 2)
4. Version 3 is loaded with state from version 2.
5. Plugin is still in failed state (`ctx.failure` == `CR_SEGFAULT`)
6. Next update does a rollback (version 3 -> 2).
7. Plugin is back to version 2 (with bad unload code).

New logic:
1. Plugin is at version 2.
2. New version 3 is detected.
3. Unload of version 2 crashes.  (State is NOT saved from version 2)
4. New version 3 is NOT loaded.  Return quickly back to host.
5. Plugin version is still 2 in failed state. (`ctx.failure` == `CR_SEGFAULT`)
6. Next update does a rollback (version 2 -> 1).
7. Plugin is back to version 1.  With state restored from backup.

It would be nicer to allow version 3 to load with state restored from backup, instead of rolling back to version 1.  But I wouldn't to allow the host to be notified of the crash.

Should we save some flag to do a load of the new version instead of rolling back after a crash from unload?
