### PR TITLE
Don't re-use version numbers after rollback

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{h,c,cpp}]
+indent_style = space
+indent_size = 4

--- a/cr.h
+++ b/cr.h
@@ -1625,8 +1625,13 @@ static bool cr_plugin_load_internal(cr_plugin &ctx, bool rollback) {
         }
 
         auto new_version = ctx.version + (rollback ? 0 : 1);
-        const auto new_file = cr_version_path(file, new_version, p->temppath);
+        auto new_file = cr_version_path(file, new_version, p->temppath);
         if (!rollback) {
+            while(cr_exists(new_file)) {
+                new_version++;
+                CR_LOG("File exists: %s (bump version: %d)\n", new_file.c_str(), new_version);
+                new_file = cr_version_path(file, new_version, p->temppath);
+            }
             cr_copy(file, new_file);
 
 #if defined(_MSC_VER)

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -22,6 +22,17 @@ void touch(const char *filename) {
 }
 #endif
 
+void delete_old_files(cr_plugin &ctx, int max_version) {
+    auto p = (cr_internal *)ctx.p;
+    const auto file = p->fullname;
+    for (unsigned int i = 0; i < max_version; i++) {
+        cr_del(cr_version_path(file, i, p->temppath));
+#if defined(_MSC_VER)
+        cr_del(cr_replace_extension(cr_version_path(file, i, p->temppath), ".pdb"));
+#endif
+    }
+}
+
 TEST(crTest, basic_flow) {
     const char *bin = CR_DEPLOY_PATH "/" CR_PLUGIN("test_basic");
 
@@ -104,12 +115,12 @@ TEST(crTest, basic_flow) {
     EXPECT_EQ(0, cr_plugin_update(ctx));
 
     // recompile code
-    // a new version 2, hopefuly with the bug fixed!
+    // a new version 3, hopefuly with the bug fixed!
     touch(bin);
 
     // should be a new version
     data.test = test_id::return_version;
-    EXPECT_EQ(2, cr_plugin_update(ctx));
+    EXPECT_EQ(3, cr_plugin_update(ctx));
 
     // test our allocated data is still good
     data.test = test_id::heap_data_alloc;
@@ -129,34 +140,34 @@ TEST(crTest, basic_flow) {
     EXPECT_EQ(0, cr_plugin_update(ctx));
 
     // recompile code
-    // version 3
+    // version 4
     touch(bin);
 
     // makes it crash during load
     // crash handler automatically decrements the version
     data.test = test_id::crash_load;
     EXPECT_EQ(-2, cr_plugin_update(ctx));
-    EXPECT_EQ((unsigned int)2, ctx.version);
+    EXPECT_EQ((unsigned int)3, ctx.version);
     EXPECT_EQ(CR_SEGFAULT, ctx.failure);
 
-    // load crashed, so it should be at version 2
+    // load crashed, so it should be at version 3
     data.test = test_id::return_version;
-    EXPECT_EQ(2, cr_plugin_update(ctx));
+    EXPECT_EQ(3, cr_plugin_update(ctx));
 
     // recompile code
-    // a new version 3 retry
+    // a new version 5 retry
     touch(bin);
 
     // force crash on unload
-    // but now the bug moved and crashed again, we're back to version 1
+    // but now the bug moved and crashed again, we're back to version 2
     data.test = test_id::crash_unload;
     EXPECT_EQ(-2, cr_plugin_update(ctx));
-    EXPECT_EQ((unsigned int)1, ctx.version);
+    EXPECT_EQ((unsigned int)2, ctx.version);
     EXPECT_EQ(CR_SEGFAULT, ctx.failure);
 
     // unload crashed, next update should do a rollback
     data.test = test_id::return_version;
-    EXPECT_EQ(1, cr_plugin_update(ctx));
+    EXPECT_EQ(2, cr_plugin_update(ctx));
 
     // modify states
     data.test = test_id::static_local_state_int;
@@ -164,6 +175,9 @@ TEST(crTest, basic_flow) {
 
     data.test = test_id::static_global_state_int;
     EXPECT_EQ(saved_global_static + 3, cr_plugin_update(ctx));
+
+    // Cleanup old version
+    delete_old_files(ctx, 10);
 
     cr_plugin_close(ctx);
     EXPECT_EQ(ctx.p, nullptr);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -22,7 +22,7 @@ void touch(const char *filename) {
 }
 #endif
 
-void delete_old_files(cr_plugin &ctx, int max_version) {
+void delete_old_files(cr_plugin &ctx, unsigned int max_version) {
     auto p = (cr_internal *)ctx.p;
     const auto file = p->fullname;
     for (unsigned int i = 0; i < max_version; i++) {
@@ -177,7 +177,7 @@ TEST(crTest, basic_flow) {
     EXPECT_EQ(saved_global_static + 3, cr_plugin_update(ctx));
 
     // Cleanup old version
-    delete_old_files(ctx, 10);
+    delete_old_files(ctx, ctx.next_version);
 
     cr_plugin_close(ctx);
     EXPECT_EQ(ctx.p, nullptr);


### PR DESCRIPTION
I have re-worked the changes needed for `cr-sys`

This PR added a `last_version` field to `cr_plugin` to keep track of the last good version.  This allows a rollback to skip over multiple crashing versions.  This was the simplest way to skip over bad versions during a rollback.

Logic:
1. plugin at version 1 -- last_version as at 1
2. recompile: plugin reloads, now at version 2 -- last_version stays at 1
3. recompile: plugin reloads, now at version 3 -- last_version is updated to 2, because version 2 didn't crash.
4. version 3 crashes.  rollback to version 2. -- last_version still at 2
5. recompile: plugin reloads, now at version 4 -- last_version stays at 2
6. version 4 crashes.  rollback to version 2. -- last_version still at 2
7. recompile: plugin reloads, now at version 5 -- last_version stays at 2
8. recompile: plugin reloads, now at version 6 -- last_version is updated to 5 (version 5 didn't crash).