### PR TITLE
Only set up signal handler once

### DIFF
--- a/cr.h
+++ b/cr.h
@@ -1557,6 +1557,11 @@ static void cr_signal_handler(int sig, siginfo_t *si, void *uap) {
 
 static void cr_plat_init() {
     CR_TRACE
+    static bool initialized = false;
+    if (initialized) {
+        return;
+    }
+    initialized = true;
     struct sigaction sa;
     sa.sa_flags = SA_SIGINFO | SA_RESTART | SA_NODEFER;
     sigemptyset(&sa.sa_mask);


### PR DESCRIPTION
A better option would probably be to remove the call to plat_init from cr_plugin_load and instead of have the library's user call plat_init once from their initialization function (main/WinMain/whatever), but I didn't want to suggest a breaking change to the API like that.