### PR TITLE
Fix test suite build for Visual Studio 16.3+

### DIFF
--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -4,7 +4,12 @@
 #include "../cr.h"
 #include "test_data.h"
 
-#if defined(CR_PLATFORM_WIN) || defined(CR_PLATFORM_LINUX)
+#if defined(CR_WINDOWS) || defined(CR_LINUX)
+#if defined(_MSC_VER)
+// avoid experimental/filesystem deprecation #error on MSVC >= 16.3 since we're
+// not using C++17 explicitly.
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+#endif
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
 


### PR DESCRIPTION
Looks like the CR_PLATFORM_* macros no longer exist, so updated those.

<experimental/filesystem> got deprecated with Visual Studio 16.3 and gives a compiler error like:
```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.24.28314\include\experimental/filesystem(30,1): fatal error C1189: #error:  The <experimental/filesystem> header providing std::experim ental::filesystem is deprecated by Microsoft and will be REMOVED. It is superseded by the C++17 <filesystem> header providing std::filesystem. You can define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING to
acknowledge that you have received this warning. [C:\Users\nslot\dev\cr-test\fips-build\cr\win64-vstudio-debug\tests\crTest.vcxproj]
```
when you try to use it.