### PR TITLE
Added support for msys64/mingw32

### DIFF
--- a/cr.h
+++ b/cr.h
@@ -405,6 +405,15 @@ platform should be supported."
 #define CR_IMPORT
 #endif // defined(__GNUC__)
 
+#if defined(__MINGW32__)
+#undef CR_EXPORT
+#if defined(__cplusplus)
+#define CR_EXPORT  extern "C" __declspec(dllexport)
+#else
+#define CR_EXPORT  __declspec(dllexport)
+#endif
+#endif
+
 // cr_mode defines how much we validate global state transfer between
 // instances. The default is CR_UNSAFE, you can choose another mode by
 // defining CR_HOST, ie.: #define CR_HOST CR_SAFEST


### PR DESCRIPTION
This PR adds support for proper CR_EXPORT macro.
Unfortunately under msys64 with mingw32 on Windows the entry point of cr_main would not be found . This PR ensures that the correct defines are used. 