### PR TITLE
Added MinGW32 SEH crash and assert protection

### DIFF
--- a/cr.h
+++ b/cr.h
@@ -321,6 +321,8 @@ With all these information you'll be able to decide which is better to your use 
 
 [@pixelherodev](https://github.com/pixelherodev)
 
+[Alexander](https://github.com/clibequilibrium)
+
 ### Contributing
 
 We welcome *ALL* contributions, there is no minor things to contribute with, even one letter typo fixes are welcome.
@@ -1113,26 +1115,26 @@ static void cr_signal_handler(int sig) {
 }
 
 static cr_failure cr_signal_to_failure(int sig) {
-  switch (sig) {
-  case 0:
-    return CR_NONE;
-  case SIGILL:
-    return CR_ILLEGAL;
-  case SIGSEGV:
-    return CR_SEGFAULT;
-  case SIGABRT:
-    return CR_ABORT;
-  }
-  return static_cast<cr_failure>(CR_OTHER + sig);
+    switch (sig) {
+    case 0:
+        return CR_NONE;
+    case SIGILL:
+        return CR_ILLEGAL;
+    case SIGSEGV:
+        return CR_SEGFAULT;
+    case SIGABRT:
+        return CR_ABORT;
+    }
+    return static_cast<cr_failure>(CR_OTHER + sig);
 }
 #endif
 
 static void cr_plat_init() {
 #ifdef __MINGW32__
-  CR_TRACE
-  signal(SIGILL, cr_signal_handler);
-  signal(SIGSEGV, cr_signal_handler);
-  signal(SIGABRT, cr_signal_handler);
+    CR_TRACE
+    signal(SIGILL, cr_signal_handler);
+    signal(SIGSEGV, cr_signal_handler);
+    signal(SIGABRT, cr_signal_handler);
 #endif
 }
 
@@ -1176,16 +1178,15 @@ static int cr_plugin_main(cr_plugin &ctx, cr_op operation) {
     }
 #else
     if (int sig = __builtin_setjmp(env)) {
-      ctx.version = ctx.last_working_version;
-      ctx.failure = cr_signal_to_failure(sig);
-      CR_LOG("1 FAILURE: %d (CR: %d)\n", sig, ctx.failure);
-      return -1;
+        ctx.version = ctx.last_working_version;
+        ctx.failure = cr_signal_to_failure(sig);
+        CR_LOG("1 FAILURE: %d (CR: %d)\n", sig, ctx.failure);
+        return -1;
     } else {
-      auto p = (cr_internal *)ctx.p;
-      CR_ASSERT(p);
-      if (p->main) {
-        return p->main(&ctx, operation);
-      }
+        CR_ASSERT(p);
+        if (p->main) {
+            return p->main(&ctx, operation);
+        }
     }
 #endif
 

--- a/cr.h
+++ b/cr.h
@@ -1139,7 +1139,7 @@ static int cr_seh_filter(cr_plugin &ctx, unsigned long seh) {
 
 extern "C" EXCEPTION_DISPOSITION ExceptionHandler (struct _EXCEPTION_RECORD* er, void* buf, struct _CONTEXT* ctx, void* buf2)
 { 
-  return ExceptionNestedException;
+  return EXCEPTION_EXECUTE_HANDLER;
 }
 #endif
 

--- a/cr.h
+++ b/cr.h
@@ -405,6 +405,15 @@ platform should be supported."
 #define CR_IMPORT
 #endif // defined(__GNUC__)
 
+#if defined(__MINGW32__)
+#undef CR_EXPORT
+#if defined(__cplusplus)
+#define CR_EXPORT  extern "C" __declspec(dllexport)
+#else
+#define CR_EXPORT  __declspec(dllexport)
+#endif
+#endif
+
 // cr_mode defines how much we validate global state transfer between
 // instances. The default is CR_UNSAFE, you can choose another mode by
 // defining CR_HOST, ie.: #define CR_HOST CR_SAFEST

--- a/cr.h
+++ b/cr.h
@@ -1107,8 +1107,10 @@ static cr_plugin_main_func cr_so_symbol(so_handle handle) {
 #include <setjmp.h>
 #include <signal.h>
 
-jmp_buf env;
-static void cr_signal_handler(int sig) { longjmp(env, sig); }
+static jmp_buf env;
+static void cr_signal_handler(int sig) {
+    __builtin_longjmp(env, 1);
+}
 
 static cr_failure cr_signal_to_failure(int sig) {
   switch (sig) {
@@ -1173,7 +1175,7 @@ static int cr_plugin_main(cr_plugin &ctx, cr_op operation) {
         return -1;
     }
 #else
-    if (int sig = setjmp(env)) {
+    if (int sig = __builtin_setjmp(env)) {
       ctx.version = ctx.last_working_version;
       ctx.failure = cr_signal_to_failure(sig);
       CR_LOG("1 FAILURE: %d (CR: %d)\n", sig, ctx.failure);

--- a/cr.h
+++ b/cr.h
@@ -1108,22 +1108,20 @@ static cr_plugin_main_func cr_so_symbol(so_handle handle) {
 #include <signal.h>
 
 jmp_buf env;
-static void cr_signal_handler(int sig) { 
-    longjmp(env, sig); 
-    }
+static void cr_signal_handler(int sig) { longjmp(env, sig); }
 
 static cr_failure cr_signal_to_failure(int sig) {
-    switch (sig) {
-    case 0:
-        return CR_NONE;
-    case SIGILL:
-        return CR_ILLEGAL;
-    case SIGSEGV:
-        return CR_SEGFAULT;
-    case SIGABRT:
-        return CR_ABORT;
-    }
-    return static_cast<cr_failure>(CR_OTHER + sig);
+  switch (sig) {
+  case 0:
+    return CR_NONE;
+  case SIGILL:
+    return CR_ILLEGAL;
+  case SIGSEGV:
+    return CR_SEGFAULT;
+  case SIGABRT:
+    return CR_ABORT;
+  }
+  return static_cast<cr_failure>(CR_OTHER + sig);
 }
 #endif
 
@@ -1176,16 +1174,16 @@ static int cr_plugin_main(cr_plugin &ctx, cr_op operation) {
     }
 #else
     if (int sig = setjmp(env)) {
-        ctx.version = ctx.last_working_version;
-        ctx.failure = cr_signal_to_failure(sig);
-        CR_LOG("1 FAILURE: %d (CR: %d)\n", sig, ctx.failure);
-        return -1;
+      ctx.version = ctx.last_working_version;
+      ctx.failure = cr_signal_to_failure(sig);
+      CR_LOG("1 FAILURE: %d (CR: %d)\n", sig, ctx.failure);
+      return -1;
     } else {
-        auto p = (cr_internal *)ctx.p;
-        CR_ASSERT(p);
-        if (p->main) {
-            return p->main(&ctx, operation);
-        }
+      auto p = (cr_internal *)ctx.p;
+      CR_ASSERT(p);
+      if (p->main) {
+        return p->main(&ctx, operation);
+      }
     }
 #endif
 

--- a/cr.h
+++ b/cr.h
@@ -1104,7 +1104,6 @@ static cr_plugin_main_func cr_so_symbol(so_handle handle) {
 }
 
 #ifdef __MINGW32__
-
 #include <setjmp.h>
 #include <signal.h>
 
@@ -1126,8 +1125,6 @@ static cr_failure cr_signal_to_failure(int sig) {
     }
     return static_cast<cr_failure>(CR_OTHER + sig);
 }
-
-
 #endif
 
 static void cr_plat_init() {


### PR DESCRIPTION
This PR adds crash protection on MinGW32 . Please note since __except is not supported on MinGW I had to use __try1 and __except1 . The only problem with my solution is that there is no way for me to get the right error code so I just return CR_OTHER. 

Also is returning -1 okay after try catch ? From my tests it introduced the correct behavior of rollback. Previously crash protection was not working at all for me. This PR tackles this issue. 


~~Please note while this PR adds crash protection it doesn't add assertation protection yet.~~

EDIT: the PR has been updated to fully support assert and crash protection in MingW32 environment