### PR TITLE
Added crash support for clang and fixed missing character with .dll name

### DIFF
--- a/cr.h
+++ b/cr.h
@@ -1954,7 +1954,7 @@ extern "C" int cr_plugin_update(cr_plugin &ctx, bool reloadCheck = true) {
         CR_LOG("1 ROLLBACK version was %d\n", ctx.version);
         cr_plugin_rollback(ctx);
         CR_LOG("1 ROLLBACK version is now %d\n", ctx.version);
-#ifdef __MINGW32__
+#if defined(__MINGW32__) || defined(__clang__)
         cr_plat_init();
 #endif
 

--- a/cr.h
+++ b/cr.h
@@ -613,7 +613,7 @@ static std::string cr_version_path(const std::string &basepath,
     // Length of path is extra space for version number. Trim file name only if version number
     // length exceeds pdb folder path length. This is not relevant on other platforms.
     if (ver.size() > folder.size()) {
-        fname = fname.substr(0, fname.size() - (ver.size() - folder.size() -1));
+        fname = fname.substr(0, fname.size() - (ver.size() - folder.size() - 1));
     }
 #endif
     if (!temppath.empty()) {


### PR DESCRIPTION
This PR adds crash support for clang (tested on Windows)."

This method uses previous working setjmp and longjmp method to catch the exceptions. 

Also this PR fixes an issue where a new dll will be created but 1 character would be missing ie:

"open-world.dll" will be created as "open-worl1.dll" with "d" letter missing . 