### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Note that the only file that matters is `cr.h`.
 This file contains the documentation in markdown, the license, the implementation and the public api.
 All other files in this repository are supporting files and can be safely ignored.
 
+### Building cr - Using vcpkg
+
+You can download and install cr using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install cr
+
+The cr port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Example
 
 A (thin) host application executable will make use of `cr` to manage

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Note that the only file that matters is `cr.h`.
 This file contains the documentation in markdown, the license, the implementation and the public api.
 All other files in this repository are supporting files and can be safely ignored.
 
-The cr port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
-
 ### Example
 
 A (thin) host application executable will make use of `cr` to manage

--- a/README.md
+++ b/README.md
@@ -22,16 +22,6 @@ Note that the only file that matters is `cr.h`.
 This file contains the documentation in markdown, the license, the implementation and the public api.
 All other files in this repository are supporting files and can be safely ignored.
 
-### Building cr - Using vcpkg
-
-You can download and install cr using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
-
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install cr
-
 The cr port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ### Example

--- a/cr.h
+++ b/cr.h
@@ -23,6 +23,18 @@ Note that the only file that matters is `cr.h`.
 This file contains the documentation in markdown, the license, the implementation and the public api.
 All other files in this repository are supporting files and can be safely ignored.
 
+### Building cr - Using vcpkg
+
+You can download and install cr using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install cr
+
+The cr port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Example
 
 A (thin) host application executable will make use of `cr` to manage


### PR DESCRIPTION
cr is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for cr and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build cr, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/cr/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)