### PR TITLE
fix inclusion via CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .fips-imports.cmake
 .fips-gen.py
+CMakeUserPresets.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,90 +1,100 @@
 {
- "isShellCommand":true,
- "version":"0.1.0",
- "showOutput":"silent",
+    "version": "2.0.0",
  "tasks":[
-  {
-   "problemMatcher":"$msCompile",
-   "taskName":"glfw3",
-   "args":[
-    "make",
-    "glfw3"
-   ]
-  },
-  {
-   "problemMatcher":"$msCompile",
-   "taskName":"googletest",
-   "args":[
-    "make",
-    "googletest"
-   ]
-  },
-  {
-   "problemMatcher":"$msCompile",
-   "taskName":"basic_guest",
-   "args":[
-    "make",
-    "basic_guest"
-   ]
-  },
-  {
-   "problemMatcher":"$msCompile",
-   "taskName":"imgui_host",
-   "args":[
-    "make",
-    "imgui_host"
-   ]
-  },
-  {
-   "problemMatcher":"$msCompile",
-   "taskName":"test_basic",
-   "args":[
-    "make",
-    "test_basic"
-   ]
-  },
-  {
-   "problemMatcher":"$msCompile",
-   "taskName":"crTest",
-   "args":[
-    "make",
-    "crTest"
-   ]
-  },
-  {
-   "problemMatcher":"$msCompile",
-   "taskName":"basic_host",
-   "args":[
-    "make",
-    "basic_host"
-   ]
-  },
-  {
-   "problemMatcher":"$msCompile",
-   "taskName":"imgui_guest",
-   "args":[
-    "make",
-    "imgui_guest"
-   ]
-  },
-  {
-   "problemMatcher":"$msCompile",
-   "taskName":"imgui",
-   "args":[
-    "make",
-    "imgui"
-   ]
-  },
-  {
-   "problemMatcher":"$msCompile",
-   "isBuildCommand":true,
-   "taskName":"ALL",
-   "args":[
-    "build"
-   ]
-  }
- ],
- "suppressTaskName":true,
+    {
+        "label": "glfw3",
+        "type": "shell",
+        "args": [
+            "make",
+            "glfw3"
+        ],
+        "problemMatcher": "$msCompile"
+    },
+    {
+        "label": "googletest",
+        "type": "shell",
+        "args": [
+            "make",
+            "googletest"
+        ],
+        "problemMatcher": "$msCompile"
+    },
+    {
+        "label": "basic_guest",
+        "type": "shell",
+        "args": [
+            "make",
+            "basic_guest"
+        ],
+        "problemMatcher": "$msCompile"
+    },
+    {
+        "label": "imgui_host",
+        "type": "shell",
+        "args": [
+            "make",
+            "imgui_host"
+        ],
+        "problemMatcher": "$msCompile"
+    },
+    {
+        "label": "test_basic",
+        "type": "shell",
+        "args": [
+            "make",
+            "test_basic"
+        ],
+        "problemMatcher": "$msCompile"
+    },
+    {
+        "label": "crTest",
+        "type": "shell",
+        "args": [
+            "make",
+            "crTest"
+        ],
+        "problemMatcher": "$msCompile"
+    },
+    {
+        "label": "basic_host",
+        "type": "shell",
+        "args": [
+            "make",
+            "basic_host"
+        ],
+        "problemMatcher": "$msCompile"
+    },
+    {
+        "label": "imgui_guest",
+        "type": "shell",
+        "args": [
+            "make",
+            "imgui_guest"
+        ],
+        "problemMatcher": "$msCompile"
+    },
+    {
+        "label": "imgui",
+        "type": "shell",
+        "args": [
+            "make",
+            "imgui"
+        ],
+        "problemMatcher": "$msCompile"
+    },
+    {
+        "label": "ALL",
+        "type": "shell",
+        "args": [
+            "build"
+        ],
+        "problemMatcher": "$msCompile",
+        "group": {
+            "_id": "build",
+            "isDefault": false
+        }
+    }
+],
  "echoCommand":true,
  "command":"fips"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,23 @@
 #
 # project: cr
 #
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.21)
 project(cr)
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
-SET(FIPS_DYNAMIC_CRT 1)
-
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-
-if (NOT CMAKE_EXPORT_FIND_PACKAGE_NAME)
+if (PROJECT_IS_TOP_LEVEL)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+  set(FIPS_DYNAMIC_CRT 1)
   get_filename_component(FIPS_ROOT_DIR "../fips" ABSOLUTE)
   include("${FIPS_ROOT_DIR}/cmake/fips.cmake")
-
-  if (NOT FIPS_IMPORT)
-    fips_setup(PROJECT cr)
+  fips_setup(PROJECT cr)
     add_definitions(-DCR_DEPLOY_PATH="${FIPS_PROJECT_DEPLOY_DIR}")
+    include_directories(cr)
     add_subdirectory(samples)
     add_subdirectory(tests)
-  endif()
+  fips_finish()
+  set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+else()
+  add_library(cr INTERFACE)
+  target_include_directories(cr INTERFACE cr)
 endif()
+

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ live-reloading of the real application in the form of dynamic loadable binary, a
 
 ```c
 #define CR_HOST // required in the host only and before including cr.h
-#include "../cr.h"
+#include "cr.h"
 
 int main(int argc, char *argv[]) {
     // the host application should initalize a plugin with a context, a plugin

--- a/cr/cr.h
+++ b/cr/cr.h
@@ -1107,7 +1107,7 @@ static so_handle cr_so_load(const std::string &filename) {
 
 static cr_plugin_main_func cr_so_symbol(so_handle handle) {
     CR_ASSERT(handle);
-    auto new_main = (cr_plugin_main_func)GetProcAddress(handle, CR_MAIN_FUNC);
+    auto new_main = (cr_plugin_main_func)(void*)GetProcAddress(handle, CR_MAIN_FUNC);
     if (!new_main) {
         CR_ERROR("Couldn't find plugin entry point: %d\n",
                 GetLastError());

--- a/cr/cr.h
+++ b/cr/cr.h
@@ -28,6 +28,11 @@ You can download and install cr using the [vcpkg](https://github.com/Microsoft/v
 
 The cr port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
+### Building cr - Using CMake FetchContent
+
+FetchContent_Declare(cr GIT_REPOSITORY https://github.com/fungos/cr GIT_TAG master)
+FetchContent_MakeAvailable(cr)
+
 ### Example
 
 A (thin) host application executable will make use of `cr` to manage
@@ -35,7 +40,7 @@ live-reloading of the real application in the form of dynamic loadable binary, a
 
 ```c
 #define CR_HOST // required in the host only and before including cr.h
-#include "../cr.h"
+#include "cr.h"
 
 int main(int argc, char *argv[]) {
     // the host application should initalize a plugin with a context, a plugin

--- a/samples/basic_guest.c
+++ b/samples/basic_guest.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <assert.h>
-#include "../cr.h"
+#include "cr.h"
 
 // To save states automatically from previous instance to a new loaded one, use CR_STATE flag on statics/globals.
 // This will create a new data section in the binary for transferable states between instances that will be copied

--- a/samples/basic_guest_b.c
+++ b/samples/basic_guest_b.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <assert.h>
-#include "../cr.h"
+#include "cr.h"
 
 // To save states automatically from previous instance to a new loaded one, use CR_STATE flag on statics/globals.
 // This will create a new data section in the binary for transferable states between instances that will be copied

--- a/samples/basic_host.cpp
+++ b/samples/basic_host.cpp
@@ -3,7 +3,7 @@
 #include <thread>
 
 #define CR_HOST CR_UNSAFE // try to best manage static states
-#include "../cr.h"
+#include "cr.h"
 
 const char *plugin = CR_DEPLOY_PATH "/" CR_PLUGIN("basic_guest");
 

--- a/samples/basic_host_b.cpp
+++ b/samples/basic_host_b.cpp
@@ -3,7 +3,7 @@
 #include <thread>
 
 #define CR_HOST CR_UNSAFE // try to best manage static states
-#include "../cr.h"
+#include "cr.h"
 
 // avoid finishing the name by a number to not clash with the version
 // as we copy the file as filenameversion.ext

--- a/samples/imgui_guest.cpp
+++ b/samples/imgui_guest.cpp
@@ -9,7 +9,7 @@
 #include <GL/gl3w.h> // gl*
 #include <GLFW/glfw3.h> // GLFW_KEY*
 
-#include "../cr.h"
+#include "cr.h"
 
 // To test imgui 100% guest side, enable this
 //#define IMGUI_GUEST_ONLY

--- a/samples/imgui_guest.cpp
+++ b/samples/imgui_guest.cpp
@@ -180,7 +180,7 @@ bool ImGui_ImplGlfwGL3_CreateFontsTexture() {
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
 
     // Store our identifier
-    io.Fonts->TexID = (void *)(intptr_t)g_FontTexture;
+    io.Fonts->TexID = (ImTextureID)(intptr_t)g_FontTexture;
 
     // Restore state
     glBindTexture(GL_TEXTURE_2D, last_texture);
@@ -334,7 +334,7 @@ bool imui_init() {
     io.SetClipboardTextFn = g_data->set_clipboard_fn;
     io.GetClipboardTextFn = g_data->get_clipboard_fn;
     io.ClipboardUserData = g_data->window;
-    io.ImeWindowHandle = g_data->wndh;
+    ImGui::GetMainViewport()->PlatformHandleRaw = g_data->wndh;
 
     return true;
 }

--- a/samples/imgui_host.cpp
+++ b/samples/imgui_host.cpp
@@ -11,7 +11,7 @@
 #endif
 
 #define CR_HOST CR_UNSAFE
-#include "../cr.h"
+#include "cr.h"
 
 const char *plugin = CR_DEPLOY_PATH "/" CR_PLUGIN("imgui_guest");
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #define CR_HOST
-#include "../cr.h"
+#include "cr.h"
 #include "test_data.h"
 
 #if defined(CR_WINDOWS) || defined(CR_LINUX)

--- a/tests/test_basic.cpp
+++ b/tests/test_basic.cpp
@@ -1,4 +1,4 @@
-#include "../cr.h"
+#include "cr.h"
 #include "test_data.h"
 #include <chrono>
 #include <cstdint>


### PR DESCRIPTION
This is a more "proper" (cmake-tested) fix for https://github.com/fungos/cr/issues/77

Now, anyone can include this repo via any git or cmake-centric mechanism, and it won't try to build its own tests/etc.

To make things clean, I had to move `cr.h` into its own folder, but then simply adding that as an INTERFACE include_dir works (tested with the samples.

Note: some of the samples/tests no longer link - dependencies are not pinned, and upstream changes have caused issues in the samples. So I was only able to compile, not link/test as some symbols are now missing.

I have fixed just enough of the code based on upstream changes to verify compilation works. I would recommend the maintainer pins their versions in the fips.yml

Happy to accept changes/requests. For now, I use this fork in my fetchcontent, but once it's merged I'll switch back.